### PR TITLE
Add --docker-params options to add extra docker run parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Build [fpm-cookery](https://github.com/forward3d/fpm-cookery) recipes with Docke
 
 ## What is this?
 
-This is a terribly-named wrapper around [fpm-cookery](https://github.com/forward3d/fpm-cookery) 
-that allows you to run fpm-cookery builds inside a container. I wrote this to allow me to run package builds 
-in development on my laptop in the same way that Jenkins runs them, and to allow easy building of packages 
+This is a terribly-named wrapper around [fpm-cookery](https://github.com/forward3d/fpm-cookery)
+that allows you to run fpm-cookery builds inside a container. I wrote this to allow me to run package builds
+in development on my laptop in the same way that Jenkins runs them, and to allow easy building of packages
 for a variety of Linux distributions.
 
 ## Why would you use this?
@@ -15,9 +15,9 @@ If you are building your own operating system packages, you should be running th
 environment every time. fpm-cookery is a superb tool for expressing the process of building and packaging
 using fpm, but it provides no real functionality for working in a clean environment.
 
-With the advent of [Docker](https://www.docker.com/), it is fast and easy to bring up an isolated 
-environment (a container) to perform the package building in. It also allows your CI server to perform 
-a very simple invocation to build packages (`fpm-dockery build recipe.rb ubuntu12.04`), and allows you 
+With the advent of [Docker](https://www.docker.com/), it is fast and easy to bring up an isolated
+environment (a container) to perform the package building in. It also allows your CI server to perform
+a very simple invocation to build packages (`fpm-dockery build recipe.rb ubuntu12.04`), and allows you
 to run the same build on your development machine in the same way.
 
 If a build fails, you can easily re-run the container and be dropped into the state where the build failed.
@@ -25,10 +25,10 @@ This makes it very easy to troubleshoot why a build is failing.
 
 ## How does it work?
 
-`fpm-dockery` has the notion of 'builder' images. These are specially prepared Docker images that 
+`fpm-dockery` has the notion of 'builder' images. These are specially prepared Docker images that
 contain enough tooling to get `fpm-cookery` working, along with `fpm-cookery` itself.
 
-You can see the Dockerfiles used to generate these images in the 
+You can see the Dockerfiles used to generate these images in the
 [`docker` directory](https://github.com/andytinycat/fpm-dockery/tree/master/docker) of this
 repository.
 
@@ -70,16 +70,16 @@ Once you've installed it, you will have access to the `fpm-dockery` command line
     $ bin/fpm-dockery --help
     Usage:
         fpm-dockery [OPTIONS] SUBCOMMAND [ARG] ...
-    
+
     Parameters:
         SUBCOMMAND                    subcommand
         [ARG] ...                     subcommand arguments
-    
+
     Subcommands:
         create-builder-image          Build one of the fpm-dockery Docker 'builder' images
         package                       Run fpm-cookery in a Docker container to produce a package
         list-builders                 List available builders
-    
+
     Options:
         -h, --help                    print help
 
@@ -90,7 +90,7 @@ optional argument:
 
     fpm-dockery package PATH_TO_RECIPE BUILDER [PACKAGE_DIR]
 
-The builder is one of the supported builder images. If the builder image does not exist on the 
+The builder is one of the supported builder images. If the builder image does not exist on the
 system where Docker is running, it will be automatically created first. The packages will be
 created in `PATH_TO_RECIPE/pkg`.
 
@@ -103,7 +103,7 @@ argument `PACKAGE_DIR`:
 
     fpm-dockery package example_recipe/recipe.rb ubuntu12.04 /tmp/somedir
 
-If you're building a package from git source, and you're using a private repository 
+If you're building a package from git source, and you're using a private repository
 (on GitHub or BitBucket or wherever), you can supply an SSH private key to build with.
 The private key __must have no passphrase__. For reasons of security, it would be wise
 to create a keypair just for your package builds, and give it only read access to the repository.
@@ -117,6 +117,12 @@ If you're working with large source files and don't want to re-download the sour
 If you'd like to make fpm-cookery skip the packaging step, supply the `--skip-package` option:
 
     fpm-dockery package --skip-package example_recipe/recipe.rb ubuntu12.04
+
+If you'd like to supply more docker run parameters, for example environment variables, supply the `--docker-params` option:
+
+    fpm-dockery package --docker-params "-e PKG_VER=2.0" example_recipe/recipe.rb ubuntu12.04
+
+
 
 ### Viewing available builders
 
@@ -156,8 +162,8 @@ some unpleasant homegrown scripts at [Forward3D](https://github.com/forward3d), 
 
 ## Acknowledgements
 
-Thanks to [@bernd](https://github.com/bernd) for creating fpm-cookery, and [@sissel](https://github.com/jordansissel) 
+Thanks to [@bernd](https://github.com/bernd) for creating fpm-cookery, and [@sissel](https://github.com/jordansissel)
 for creating FPM, without which life would be less pleasant.
 
-I also used the Redis example recipe from @bernd's repository and placed it in this repository so it can be used 
+I also used the Redis example recipe from @bernd's repository and placed it in this repository so it can be used
 for a quick proof-of-concept.


### PR DESCRIPTION
Adding the ability to pass arbitrary parameters to `docker run` because we need to pass environment variables into builds at Scale Factory.
